### PR TITLE
Repair VTK output and add proper treatment for Cartesian runs

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -234,7 +234,9 @@ void printParameters() {
   cout << "smoothingType = " << smoothingType << endl;
   cout << "impactPar = " << impactPar << endl;
   cout << "s0ScaleFactor = " << s0ScaleFactor << endl;
-  cout << "VTK_output_values = " << vtk_values << endl;
+  if (!vtk_values.empty()) {
+    cout << "VTK_output_values = " << vtk_values << endl;
+  }
   cout << "======= end parameters =======\n";
 }
 
@@ -401,12 +403,17 @@ int main(int argc, char **argv) {
  //f->outputCorona(tau0);
 
  bool resized = false; // flag if the grid has been resized
- 
+
  int timestep = 0;
- int nelements = 1;  
+ int nelements = 1;
+ std::string dir=outputDir.c_str();
+ VtkOutput vtk_out=VtkOutput(dir,eos,xmin,ymin,etamin);
  do {
   // small tau: decrease timestep by making substeps, in order
   // to avoid instabilities in eta direction (signal velocity ~1/tau)
+  if (!vtk_values.empty()) {
+    vtk_out.write(*h,vtk_values);
+  }
   int nSubSteps = 1;
   #ifdef CARTESIAN
   ctime = h->time();
@@ -424,14 +431,14 @@ int main(int argc, char **argv) {
    }
    h->setDtau(h->getDtau() * nSubSteps);
    cout << "timestep reduced by " << nSubSteps << endl;
-  } else 
+  } else
    h->performStep();
-  
+
   if (icModel == 9)
   {
     if (particles->size() > 0) h->addParticles(particles);
   }
-  
+
   if ((ctime > timeInitFO) && (nelements>0)) {
     nelements = f->outputSurface(ctime);
     if (!corona_was_output) {
@@ -449,7 +456,7 @@ int main(int argc, char **argv) {
     }
     break;
   }
-    
+
   if(ctime>=tauResize and resized==false) {
    cout << "grid resize\n";
    f = expandGrid2x(h, eos, eosH, trcoeff);
@@ -462,7 +469,7 @@ int main(int argc, char **argv) {
  time(&end);
  float diff2 = difftime(end, start);
  cout << "Execution time = " << diff2 << " [sec]" << endl;
- 
+
  delete f;
  delete h;
  delete eos;

--- a/src/vtk.cpp
+++ b/src/vtk.cpp
@@ -46,7 +46,11 @@ void VtkOutput::write_vtk_scalar(std::ofstream &file, const Hydro h,
       for (int ix = 0; ix < num_of_cells_x_direction_; ix++) {
         double e, nb, nq, ns, p, vx, vy, vz;
         Cell* cell = h.getFluid()->getCell(ix,iy,ieta);
-        cell->getPrimVar(eos_, h.getTau(), e, p, nb, nq, ns, vx, vy, vz);
+        #ifdef CARTESIAN
+          cell->getPrimVar(eos_, 1.0, e, p, nb, nq, ns, vx, vy, vz);
+        #else
+          cell->getPrimVar(eos_, h.getTau(), e, p, nb, nq, ns, vx, vy, vz);
+        #endif
         double q = 0;
         // scalar quantities
         if (quantity == "eps") {
@@ -94,7 +98,11 @@ void VtkOutput::write_vtk_vector(std::ofstream &file, const Hydro h,
       for (int ix = 0; ix < num_of_cells_x_direction_; ix++) {
         double e, p, nb, nq, ns, vx, vy, vz;
         Cell* cell = h.getFluid()->getCell(ix,iy,ieta);
-        cell->getPrimVar(eos_, h.getTau(), e, p, nb, nq, ns, vx, vy, vz);
+        #ifdef CARTESIAN
+          cell->getPrimVar(eos_, 1.0, e, p, nb, nq, ns, vx, vy, vz);
+        #else
+          cell->getPrimVar(eos_, h.getTau(), e, p, nb, nq, ns, vx, vy, vz);
+        #endif
         std::vector<double> q = {0.,0.,0.};
         if (quantity == "v") {
           q = {vx, vy, vz};


### PR DESCRIPTION
I noticed that the VTK output was "damaged" when a few commits from `stable_ebe` were merged into the `dynamicalIC` branch in PR #3, i.e., the important part to initialize the output was not in the merge.

@zpauliny, I fixed this and added proper treatment of the VTK output in Cartesian runs since I wanted to animate a few hybrid dynamical IC runs and thought this might lead to an easier merge with the `main` branch in the future.